### PR TITLE
Replace the `resize` event listener with `window.matchMedia`

### DIFF
--- a/src/globe/globe.js
+++ b/src/globe/globe.js
@@ -23,8 +23,10 @@ let saveData = navigator.connection && navigator.connection.saveData
 if (window.innerWidth > 980 || !saveData) {
   earth[0]()
 } else {
-  window.addEventListener('resize', () => {
-    if (window.innerWidth > 980) earth[0]()
+  window.matchMedia("(min-width: 981px)").addListener((event) => {
+    if (event.matches) {
+      earth[0]()
+    }
   })
 }
 


### PR DESCRIPTION
Notes:

* I used `min-width: 981px` to match the strict greater sign in `window.innerWidth > 980`
* I wasn’t able to test if `window.matchMedia().addListener` works in IE (it does work in Edge). Please let me know if you need to support IE too.

---

Side note: is the `window.innerWidth > 980 || !saveData` logic introduced in 830d606aba9960378c1e73841fb9dd8d6d2c303e correct? Should there, by chance, be `&&` instead of `||`, or have you intended to change the mobile behavior?

Before the change, the logic behind looked like this:
```
window.innerWidth > 980 → Download the globe
window.innerWidth <= 980 → Don’t download the globe
```

After the change, it became as follows:
```
window.innerWidth > 980 → Download the globe
window.innerWidth <= 980 and saveData → Don’t download the globe
window.innerWidth <= 980 and !saveData → Download the globe
```

Basically, the desktop still always downloads the globe; but the mobile now also downloads the globe if `navigator.connection.saveData` is false.