### PR TITLE
Experimental: h2 push the redirect target along with the redirect

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -9,11 +9,15 @@
   to = "/ru/"
   conditions = { Language = ["ru"] }
   status = 302
+  [redirects.headers]
+    Link = "</ru/>; rel=preload; as=document"
 
 [[redirects]]
   from = "/"
   to = "/en/"
   status = 302
+  [redirects.headers]
+    Link = "</en/>; rel=preload; as=document"
 
 [[headers]]
   for = "*"


### PR DESCRIPTION
Netlify states it [initiates the h2 push from Link header](https://www.netlify.com/blog/2017/07/18/http/2-server-push-on-netlify/) After this change it should push the /en/ & /ru/ contents right with the redirect to these pages